### PR TITLE
Fixed compile error on delphi 5

### DIFF
--- a/AsyncCalls.pas
+++ b/AsyncCalls.pas
@@ -1968,8 +1968,14 @@ begin
       Msg.Result := DefWindowProc(FMainThreadVclHandle, Msg.Msg, Msg.WParam, Msg.LParam);
     end;
   except
-    if Assigned(ApplicationHandleException) then
+  {$IFDEF DELPHI5}
+  if Assigned(Application) then
+    Application.HandleException(Self);
+  {$ELSE}
+  if Assigned(ApplicationHandleException) then
       ApplicationHandleException(Self);
+  {$ENDIF DELPHI5}
+
   end;
 end;
 
@@ -2047,7 +2053,9 @@ begin
   // or just ignoring it.
   if FFatalException <> nil then
   begin
-    if Assigned(ApplicationHandleException) and
+  {$IFDEF DELPHI5} if Assigned(Application) and
+           {$ELSE} if Assigned(ApplicationHandleException) and
+  {$ENDIF DELPHI5}
        (ThreadPool.FMainThreadVclHandle <> 0) and IsWindow(ThreadPool.FMainThreadVclHandle) then
       PostMessage(ThreadPool.FMainThreadVclHandle, WM_RAISEEXCEPTION, WPARAM(FFatalErrorAddr), LPARAM(FFatalException))
     else


### PR DESCRIPTION
Couldn't compile the project on Delphi5;
![image](https://user-images.githubusercontent.com/15970071/67681487-ba21e800-f98d-11e9-970f-f1c7478fadba.png)

Now it works just fine. (Only tested it on Delphi 5)

Other users reported the same issue:
https://stackoverflow.com/questions/43186758/applicationhandleexception-variable-in-delphi-5

Thanks to David Heffernan.
https://stackoverflow.com/users/505088/david-heffernan